### PR TITLE
Add copy ctor example

### DIFF
--- a/cpp/copy.cc
+++ b/cpp/copy.cc
@@ -40,7 +40,7 @@ int main() {
   copy a(1);
   copy b(2);
 
-  copy c = copy(a);
+  copy c = a;
   copy d(b);
   b = a;
   a = mirror(a);

--- a/cpp/copy.cc
+++ b/cpp/copy.cc
@@ -1,0 +1,54 @@
+#include <iostream>
+
+class copy {
+  private:
+    int *a_;
+
+  public:
+    copy(int a) {
+      a_ = new int(a);
+    }
+    ~copy() {
+      delete a_;
+    }
+    copy(const copy &cp) {
+      std::cout << "Copy constructor called" << std::endl;
+
+      a_ = new int(cp.a());
+    }
+    copy& operator=(copy rhs) {
+      std::cout << "Copy assignment called" << std::endl;
+
+      swap(*this, rhs);
+
+      return *this;
+    }
+
+    friend void swap(copy &first, copy &second) {
+      std::swap(first.a_, second.a_);
+    }
+    int a() const {
+      return *a_;
+    }
+};
+
+copy mirror(copy a) {
+  return a;
+}
+
+int main() {
+  copy a(1);
+  copy b(2);
+
+  copy c = copy(a);
+  copy d(b);
+  b = a;
+  a = mirror(a);
+
+  std::cout << a.a() << std::endl; // 1
+  std::cout << b.a() << std::endl; // 1
+  std::cout << c.a() << std::endl; // 1
+  std::cout << d.a() << std::endl; // 2
+
+  return 0;
+}


### PR DESCRIPTION
## Lessons learned

* `Class a = Class(b)` is redundant
* `Class a = b` is equivalent to `Class a(b)`; invokes the copy constructor
* "Copy and swap" idiom should be implemented as a friend
* Copy constructor called when returning a value (not always; compiler allowed to optimize, RVO)
  * Intuition; local object is going out of scope, needs to be copied outside function scope
